### PR TITLE
Adjust inter and extrapolation of `gmt` onto observation times

### DIFF
--- a/attrici/detrend.py
+++ b/attrici/detrend.py
@@ -405,15 +405,14 @@ def detrend(config: Config, progressbar=False, use_cache=False, overwrite=False)
 
     indices = get_task_indices(lat_lon_indices, config.task_id, config.task_count)
 
-    t_scaled = (obs_data.time - obs_data.time.min()) / (
-        obs_data.time.max() - obs_data.time.min()
+    # `gmt.time` is a subset of `obs_data.time` (e.g. every 10th day)
+    # hence, interpolate these values to the full time series
+    # the last few days are extrapolated
+    gmt_on_obs_times = gmt.interp(
+        time=obs_data.time, kwargs={"fill_value": "extrapolate"}
     )
-    gmt_on_obs_times = np.interp(t_scaled, np.linspace(0, 1, len(gmt)), gmt)
-    gmt_scaled_values = (gmt_on_obs_times - gmt_on_obs_times.min()) / (
+    gmt_scaled = (gmt_on_obs_times - gmt_on_obs_times.min()) / (
         gmt_on_obs_times.max() - gmt_on_obs_times.min()
-    )
-    gmt_scaled = xr.DataArray(
-        gmt_scaled_values, coords={"time": obs_data.time}, dims=("time",)
     )
 
     startdate = config.start_date


### PR DESCRIPTION
Before, the `gmt` time series was stretched to observation times and interpolated in between. This fixes the stretch by extrapolating the additional days missing at the end using xarray (https://docs.xarray.dev/en/stable/generated/xarray.DataArray.interp.html). So far, these have only been less than 10.

This change yields some minor differences in output values as below. This would be an opportunity to update the reference ("desired") data set using the new code.

- `tas`
  Mismatched elements: `40405 / 44925 (89.9%)`
  Max absolute difference: `0.00268306`
  Max relative difference: `9.56928877e-06`
  `actual:  array([265.938872, 263.537327, 263.393717, ..., 279.529727, 278.219363, 277.543571])`
  `desired: array([265.938842, 263.537296, 263.393686, ..., 279.528476, 278.218048, 277.542196])`

- `tasskew`
  Mismatched elements: `44201 / 44925 (98.4%)`
  Max absolute difference: `0.00010132`
  Max relative difference: `0.00030966`
  `actual:  array([0.59104 , 0.578195, 0.424484, ..., 0.455711, 0.426205, 0.509888])`
  `desired: array([0.591039, 0.578194, 0.424483, ..., 0.455625, 0.42612 , 0.509804])`

- `tasrange`
  Mismatched elements: `25232 / 44925 (56.2%)`
  Max absolute difference: `0.00030414`
  Max relative difference: `3.10712416e-05`
  `actual:  array([6.405501, 2.079143, 4.204534, ..., 1.656265, 2.627698, 2.978045])`
  `desired: array([6.405501, 2.079143, 4.204533, ..., 1.656214, 2.627617, 2.977952])`

- `ps`
  Mismatched elements: `36450 / 44925 (81.1%)`
  Max absolute difference: `0.39365146`
  Max relative difference: `4.08984222e-06`
  `actual:  array([98008.40417 , 98347.605052, 98528.59211 , ..., 97054.805638, 97274.423121, 96459.794494])`
  `desired: array([98008.398762, 98347.599598, 98528.586623, ..., 97054.509612, 97274.114309, 96459.473709])`

- `hurs`
  Mismatched elements: `37940 / 44925 (84.5%)`
  Max absolute difference: `0.00069123`
  Max relative difference: `1.37780455e-05`
  `actual:  array([92.909477, 91.312848, 87.183917, ..., 80.658298, 81.257607, 81.613646])`
  `desired: array([92.909479, 91.312848, 87.183913, ..., 80.658329, 81.257634, 81.613666])`

- `rsds`
  Mismatched elements: `44271 / 44925 (98.5%)`
  Max absolute difference: `0.03822743`
  Max relative difference: `0.0066553`
  `actual:  array([31.412014, 41.785989, 34.165635, ..., 10.850706, 27.515022, 20.244547])`
  `desired: array([31.412037, 41.786009, 34.165653, ..., 10.852434, 27.5166  , 20.245965])`

- `rlsds`
  Mismatched elements: `43121 / 44925 (96%)`
  Max absolute difference: `0.01451909`
  Max relative difference: `5.58586557e-05`
  `actual:  array([240.147832, 218.330501, 214.586922, ..., 326.129449, 285.942123, 285.195691])`
  `desired: array([240.147845, 218.330517, 214.58694 , ..., 326.134107, 285.94692 , 285.200637])`

- `sfc_wind`
  Mismatched elements: `40937 / 44925 (91.1%)`
  Max absolute difference: `0.00020181`
  Max relative difference: `2.92470805e-05`
  `actual:  array([3.44585 , 2.942172, 2.210839, ..., 6.969687, 4.79171 , 5.301441])`
  `desired: array([3.44585 , 2.942172, 2.210839, ..., 6.96973 , 4.79174 , 5.301475])`
