### PR TITLE
Add .zenodo.json for authors, license, and funding

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,33 @@
+{
+    "creators": [
+        {
+            "name": "Mengel, Matthias",
+            "orcid": "0000-0001-6724-9685",
+            "affiliation": "Potsdam Institute for Climate Impact Research"
+        },
+        {
+            "name": "Treu, Simon",
+            "orcid": "0000-0002-7001-5983",
+            "affiliation": "Potsdam Institute for Climate Impact Research"
+        },
+        {
+            "name": "Schmidt, Benjamin",
+            "orcid": "0000-0002-9669-3360",
+            "affiliation": "TU Berlin"
+        },
+        {
+            "name": "Gieseke, Robert",
+            "orcid": "0000-0002-1236-5109",
+            "affiliation": "Potsdam Institute for Climate Impact Research"
+        },
+        {
+            "name": "Willner, Sven",
+            "orcid": "0000-0001-6798-6247",
+            "affiliation": "Potsdam Institute for Climate Impact Research"
+        }
+    ],
+    "license": "gpl-3.0",
+    "grants": [
+        {"id": "10.13039/501100000780::101135481"}
+    ]
+}


### PR DESCRIPTION
* This makes sure that GitHub releases archived on Zenodo properly capture the associated funding, which is a required field for the COMPASS Zenodo community.
* It also concretely specifies the license and authors along with their ORCiDs and affiliations.

---

Hi there :wave:

This is related to the Zenodo support Ticket#3313700, regarding the recent failed releases of the repository. I've taken the liberty to open a Pull Request to add a `.zenodo.json` file, which makes sure that a) the record doesn't fail publishing on Zenodo, and b) includes rich metadata for authors and the project license.

Please feel free to verify/correct the referenced ORCiDs for each author. I looked them up on ORCiD and made some guesses based on affiliations and prior works.